### PR TITLE
Update SolarController.ino instructions for VICTRON_NAME

### DIFF
--- a/SolarController/SolarController.ino
+++ b/SolarController/SolarController.ino
@@ -24,6 +24,8 @@ Settings (cog) >  3 dots (top right) > Product-Info > scroll down > encryption k
 The target device must be nominated in VSC.h as follows: 
 #define VICTRON_ADDRESS <device_address>
 #define VICTRON_NAME    <device_name>
+If you are using this code for several controllers, you can enable the loadKey() function to 
+load the required encryption key by adding the <device_name> for each controller into loadKey().
 
 The <encryption key> unique to the device must be declared as the 16 byte array key_SC[] in VSC.cpp
 ---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
In the introduction the explanation for VICTRON_NAME is expanded, including purpose of loadKey() function, which is disabled by default